### PR TITLE
Fix Tailwind configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,9 @@
-import tailwindcss from '@tailwindcss/postcss';
+import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
 export default {
-  plugins: [
-    tailwindcss(),
-    autoprefixer(),
-  ],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
-export default {
+import { defineConfig } from 'tailwindcss';
+
+export default defineConfig({
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',
@@ -7,4 +9,4 @@ export default {
     extend: {},
   },
   plugins: [],
-};
+});


### PR DESCRIPTION
## Summary
- fix PostCSS plugin references so Tailwind v4 actually runs
- wrap Tailwind config with `defineConfig`

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run preview` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512116f388832e889c8d028c0276d6