### PR TITLE
Fix Tailwind config for ESM usage

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 // tailwind.config.js
-module.exports = {
+export default {
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- use `export default` in `tailwind.config.js` so that Node can load it when `type: module` is specified

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851240af7bc832ebdb6d5402bde2803