### PR TITLE
Fix configs for ESM

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,6 @@
-// postcss.config.js
-import tailwindcss from '@tailwindcss/postcss';
+import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
-/** @type {import('postcss').Config} */
 export default {
-  plugins: [tailwindcss(), autoprefixer()],
+  plugins: [tailwindcss, autoprefixer],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
-// tailwind.config.js
-export default {
+import { defineConfig } from 'tailwindcss';
+
+export default defineConfig({
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',
@@ -8,4 +9,4 @@ export default {
     extend: {},
   },
   plugins: [],
-};
+});


### PR DESCRIPTION
## Summary
- switch tailwind config to ESM with `defineConfig`
- simplify postcss config for ESM

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685124c0b808832ea5999575255bfb82